### PR TITLE
v1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "microsoft-security-devops-azdevops",
-    "version": "1.7.2",
+    "version": "1.9.1",
     "description": "Microsoft Security DevOps for Azure DevOps.",
     "author": "Microsoft Corporation",
     "license": "MIT",
@@ -13,7 +13,7 @@
         "test": "npx mocha **/*.tests.js"
     },
     "dependencies": {
-        "@microsoft/security-devops-azdevops-task-lib": "1.7.2",
+        "@microsoft/security-devops-azdevops-task-lib": "1.9.0",
         "azure-pipelines-task-lib": "4.3.1",
         "azure-pipelines-tool-lib": "2.0.4"
     },

--- a/src/MicrosoftSecurityDevOps/v1/task.json
+++ b/src/MicrosoftSecurityDevOps/v1/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 9,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": true,
     "minimumAgentVersion": "1.83.0",

--- a/src/extension-manifest-debug.json
+++ b/src/extension-manifest-debug.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "microsoft-security-devops-azdevops",
   "name": "Microsoft Security DevOps (Debug)",
-  "version": "1.9.0.0",
+  "version": "1.9.1.0",
   "publisher": "ms-securitydevops",
   "description": "Build tasks for performing security analysis.",
   "public": false,

--- a/src/extension-manifest.json
+++ b/src/extension-manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "microsoft-security-devops-azdevops",
   "name": "Microsoft Security DevOps",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "publisher": "ms-securitydevops",
   "description": "Build tasks for performing security analysis.",
   "public": true,


### PR DESCRIPTION
* Update the security-devops-azdevops-task-lib to v1.9.0
   * Compares all versions returned by the NuGet REST API and returns the highest latest or latest prerelease version, when those are the relevant targets. This fixes a bug that assumed the order and direction of the returned package versions array.