### PR TITLE
Removed old node6 task declaration to work around ADO 'block node6' bug

### DIFF
--- a/src/MicrosoftSecurityDevOps/v1/task.json
+++ b/src/MicrosoftSecurityDevOps/v1/task.json
@@ -11,8 +11,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 11,
-        "Patch": 0
+        "Minor": 12,
+        "Patch": 1
     },
     "preview": true,
     "minimumAgentVersion": "1.83.0",
@@ -116,9 +116,6 @@
             "target": "index.js"
         },
         "Node10": {
-            "target": "index.js"
-        },
-        "Node": {
             "target": "index.js"
         }
     }

--- a/src/extension-manifest-debug.json
+++ b/src/extension-manifest-debug.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "microsoft-security-devops-azdevops",
   "name": "Microsoft Security DevOps (Debug)",
-  "version": "1.11.0.0",
+  "version": "1.12.1.0",
   "publisher": "ms-securitydevops",
   "description": "Build tasks for performing security analysis.",
   "public": false,

--- a/src/extension-manifest.json
+++ b/src/extension-manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "microsoft-security-devops-azdevops",
   "name": "Microsoft Security DevOps",
-  "version": "1.11.0",
+  "version": "1.12.1",
   "publisher": "ms-securitydevops",
   "description": "Build tasks for performing security analysis.",
   "public": true,


### PR DESCRIPTION
By declaring the extension able to run on the default `node`, ADO was detecting our task as being one that used node6, because that was technically available as a fallback. We've removed this, and the extension runs again with the node6 restriction enabled.

Closes #44 